### PR TITLE
:book: Document cmake-re --distributed and associated RBE_service + RBE_tls_client_auth_* env vars

### DIFF
--- a/0350-cmake-re-cli-reference.md
+++ b/0350-cmake-re-cli-reference.md
@@ -4,12 +4,13 @@ title: 👩🏼‍💻 cmake-re --help | Command Line Reference
 
 **CMake RE :** CMake Remote Execution, transparent cmake wrapper with build isolation and caching capabilities.
 
-If you know to use `cmake`, using `cmake-re` is a drop-in replacement which runs cached and hermetic builds by default.
+If you know to use `cmake`, using `cmake-re` is a drop-in which runs cached and hermetic builds by default.
 
 The key differences to plain `cmake` are : 
 
-  * [`--remote`](#hermetic---remote---host) Builds remotely in an isolated + hermetic environment
-  * [`--host`](#hermetic---remote---host) Disable local containerized build. Builds locally on this host without isolation or hermeticity but with caching.
+  * [`--distributed`](#--distributed) Builds on a Remote Build Execution Cluster (e.g. [EngFlow Deployment](https://engflow.com))
+  * [`--remote`](#hermetic---remote---host---distributed) Builds remotely in an isolated + hermetic environment
+  * [`--host`](#hermetic---remote---host---distributed) Disable local containerized build. Builds locally on this host without isolation or hermeticity but with caching.
   * [`--monitor|-m`](#--monitor-m) Monitors source tree, rebuilding on every changes.
 
 ## Configure : `cmake-re`
@@ -32,11 +33,21 @@ cmake-re [<<path-to-source>>]
   [-j|--jobs <cpus>]   
 ```
 
-### Hermetic, `--remote`, `--host`
-Not specifying any of these options launches a containerized build by default.
+### Hermetic, `--remote`, `--host`, `--distributed`
+Not specifying any of these options launches an hermetic containerized build by default.
 * `--remote`                Builds remotely in an isolated + hermetic environment.
 * `--host`                  Disable local containerized build. Builds locally on this host without isolation or hermeticity but with caching.
 * `-j, --jobs <cpus>`       How many CPU cores have to be dedicated to the build.
+
+### `--distributed`
+Distributes the build on a private Remote Build Execution Cluster deployment (e.g. [EngFlow Deployment](https://engflow.com))
+
+Can be used on a default hermetic containerized build or combined with `--remote` or `--host`
+
+#### Environment variables required
+* `RBE_service=<cluster-host>:<port>` : Remote Build Execution Cluster to distribute the build on.
+* `RBE_tls_client_auth_key` : User specific mTLS authentication private key to RBE_service
+* `RBE_tls_client_auth_cert` : User specific mTLS authentication public certificate to RBE_service
 
 ### Mandatory
 * `-S <<path-to-source>`    Path to directory with the `CMakeLists.txt` file of the CMake RE project to build.

--- a/0350-cmake-re-cli-reference.md
+++ b/0350-cmake-re-cli-reference.md
@@ -4,7 +4,7 @@ title: 👩🏼‍💻 cmake-re --help | Command Line Reference
 
 **CMake RE :** CMake Remote Execution, transparent cmake wrapper with build isolation and caching capabilities.
 
-If you know to use `cmake`, using `cmake-re` is a drop-in which runs cached and hermetic builds by default.
+When familiar with cmake, switching to cmake-re is seamless, with support for cached and hermetic builds by default.
 
 The key differences to plain `cmake` are : 
 
@@ -45,7 +45,7 @@ Distributes the build on a private Remote Build Execution Cluster deployment (e.
 Can be used on a default hermetic containerized build or combined with `--remote` or `--host`
 
 #### Environment variables required
-* `RBE_service=<cluster-host>:<port>` : Remote Build Execution Cluster to distribute the build on.
+* `RBE_service=<cluster-address>:<port>` : Remote Build Execution Cluster to distribute the build on.
 * `RBE_tls_client_auth_key` : User specific mTLS authentication private key to RBE_service
 * `RBE_tls_client_auth_cert` : User specific mTLS authentication public certificate to RBE_service
 

--- a/1500-environment-variables.md
+++ b/1500-environment-variables.md
@@ -5,18 +5,26 @@ aliases: [ "06-environment-variables" ]
 
 
 
-## Using a private tipi.build instance: `TIPI_ENDPOINT`
+## Using a private `cmake-re` deployment instance: `TIPI_ENDPOINT` &amp; `RBE_service`
 
-tipi.build can be run on premise or in a private deployment. All users of that deployment need to specify `TIPI_ENDPOINT` in their environment
-to their `tipi` CLI to access the correct installation.
+`cmake-re` can be run on a private cloud deployment or on-prem. All users of that deployment need to specify `TIPI_ENDPOINT` &amp; `RBE_service` in their environment, so that the `cmake-re` and `tipi` CLI access the correct installation.
+
+The syntax for these environment variables are : 
+* `TIPI_ENDPOINT=https://<deployment-hostname>` ( without ending `/` )
+* `RBE_service=<cluster-host>:<port>`
 
 ## Command line authentication
 
 In non-interactive situation (a CI/CD job, other automated usages) it might be required to provide the `tipi` CLI with
 credentials to access private repositories or make use of the tipi subscription.
 
+### tipi vault authentication
 - `TIPI_ACCESS_TOKEN` and `TIPI_REFRESH_TOKEN` are JWT tokens enabling `tipi` to get access to the tipi subscription.
 - `TIPI_VAULT_PASSPHRASE` has to be supplied in situations where the user's Vault must be decrypted (ex. accessing private repositories)
+
+### Distributed build authentication
+- `RBE_tls_client_auth_key` : User specific mTLS authentication private key to RBE_service
+- `RBE_tls_client_auth_cert` : User specific mTLS authentication public certificate to RBE_service
 
 ## Customizing tools distribution `TIPI_DISTRO_JSON`
 

--- a/1500-environment-variables.md
+++ b/1500-environment-variables.md
@@ -7,11 +7,11 @@ aliases: [ "06-environment-variables" ]
 
 ## Using a private `cmake-re` deployment instance: `TIPI_ENDPOINT` &amp; `RBE_service`
 
-`cmake-re` can be run on a private cloud deployment or on-prem. All users of that deployment need to specify `TIPI_ENDPOINT` &amp; `RBE_service` in their environment, so that the `cmake-re` and `tipi` CLI access the correct installation.
+`cmake-re` can be run on a private cloud deployment or on-prem. All users of that deployment need to specify `TIPI_ENDPOINT` &amp; `RBE_service` in their environment, so that the `cmake-re` and `tipi` CLI access the correct deployment.
 
 The syntax for these environment variables are : 
-* `TIPI_ENDPOINT=https://<deployment-hostname>` ( without ending `/` )
-* `RBE_service=<cluster-host>:<port>`
+* `TIPI_ENDPOINT=https://<deployment-address>` ( without ending `/` )
+* `RBE_service=<cluster-address>:<port>`
 
 ## Command line authentication
 


### PR DESCRIPTION
As introduced by cmake-re v0.0.71

Fix tipi-build/specs-cmake-re#169