### PR TITLE
:book: updating documentation to match upcoming cmake v0.0.73

### DIFF
--- a/0400-environments.md
+++ b/0400-environments.md
@@ -107,7 +107,7 @@ These scripts could be used as follow to make a build environment based on Ubunt
 #### `environments/linux.pkr.js/linux.Dockerfile`
 
 >
-> **NOTE:** This example environment doesn't contain any compiler. The custom environments need to provide the toolchains manually by installing the required tools as required. More complete examples can be found in [tipi-build/environments](https://github.com/tipi-build/environments)
+> **NOTE:** This example environment doesn't contain any compiler. The custom environments need to provide the toolchains manually by installing the required tools. The official reusable environments can serve as-is or as examples : [tipi-build/environments](https://github.com/tipi-build/environments)
 
 ```Dockerfile
 ARG UBUNTU_24_04="ubuntu@sha256:04f510bf1f2528604dc2ff46b517dbdbb85c262d62eacc4aa4d3629783036096"
@@ -146,7 +146,7 @@ The folder `environments/linux.pkr.js/` will be the used as docker build context
   ]
 }
 ```
-> With this environment description `cmake-re` will pull the image `tipibuild/testapp-cmake-re-containerized:latest` and use it is valid.
+> With this environment description `cmake-re` will pull the image `tipibuild/testapp-cmake-re-containerized:latest` and use it if it matches the linux.pkr.js/ content.
 > Should it not exist or be *outdated* the `environments/linux.pkr.js/linux.Dockerfile` will be used to create or update it.
 
 Please note that `cmake-re` will rely on the provided image to contain an installation matching the version of `cmake-re` used on the host system. Interoperability between different versions is not guaranteed. 
@@ -160,7 +160,7 @@ If required, `cmake-re` can inject version information into the environment desc
 > ...
 > ```
 
-**Optionally** the `image` reference in `.pkr.js` environment description can be replaced with a *hard reference* (e.g. the docker image name with a repository digest referencing one exact immutable image) to pin the image. In this case the environment description does not need to contain a Dockerfile.
+**Optionally** the `image` reference in `.pkr.js` environment description can be replaced with a *hard reference* (e.g. the docker image name with a repository manifest digest referencing one exact immutable image) to pin the image. In this case the environment description does not need to contain a Dockerfile.
 
 #### Detection of image validity
 

--- a/0400-environments.md
+++ b/0400-environments.md
@@ -26,19 +26,23 @@ A **Generalized toolchain** is a toolchain and it's accompanying environment spe
   2. File times won't affect the environment build process ( e.g. To guarantee cache use on OS Image / Docker creation )
 
 ### Configurability
-Because generalization essentially picks all files in the toolchain directory, while not necessary, it's possible to configure it with [`<toolchain-name>.layers.json files`](./0410-environments-layering.md) to better compose and isolate toolchains from each other even when they are located right next to each other.
 
+Depending on how the environment descriptions and toolchains are stored changes to unrelated environments can affect the environment description hash that is computed during environment generalization because by default all files in the same directory than the referenced toolchain will be consumed.
+In order to better compose and isolate environment specifications it is possible to configure the exact contents using [`<toolchain-name>.layers.json files`](./0410-environments-layering.md).
 
 ## OS Image File Lookup Rule
+
 The environments specifications are pointed to for a build via the `cmake-re` `-DCMAKE_TOOLCHAIN_FILE=<toolchain>.cmake` command line parameter. 
 
 OS Image are described as `.pkr.js/` folders. In order to determine the OS Image `cmake-re` looks for the **most specialized** OS Image it can find picking : 
-1. The `<toolchain>.pkr.js` with the **exact same name** than `<toolchain>.cmake`
-2. The next `.pkr.js` file which **shares the most starting character** with `<toolchain>` in the same folder.
+1. The `<toolchain>.pkr.js` with the **exact toolchain name** as `<toolchain>.cmake`
+2. The `*.pkr.js` file which **shares the most starting character** with `<toolchain>` in the same folder.
 3. If this doesn't yield any results, it perfoms the same search in the default environments directory `/usr/local/share/.tipi/<distro>/environments/` (or `C:\.tipi\<distro>\environments\`).
 
 ### OS Image Lookup Example 
+
 Given the following example set of toolchain files : 
+
 ```
 └── environments
     ├── linux-cxx17.cmake
@@ -56,29 +60,54 @@ When `cmake-re` is provided `-DCMAKE_TOOLCHAIN_FILE=environments/linux-cxx23.cma
 Because in this example there are no `environments/linux-cxx23.layers.json` any change to `linux.pkr.js` would also affect rebuilding any code dependent `linux-cxx23.cmake`, if this isn't desired it's possible to add [`linux-cxx23.layers.json`](./0410-environments-layering.md) to isolate environments, while still giving possibility to compose common cmake modules.  
 
 ## Default Environments
-Officially supported environments can be found in the [tipi-build/environments](https://github.com/tipi-build/environments) GitHub repository, they can be used as example to build custom environments.
+Officially supported environments can be found in the [tipi-build/environments](https://github.com/tipi-build/environments) GitHub repository, they can be used as example for custom environments.
 
 They are unpacked in the default environments directory `/usr/local/share/.tipi/<distro>/environments/` (or `C:\.tipi\<distro>\environments\`).
 
-## Custom Environments
+The `disto` ID key can be found by running `cmake-re --version` or `tipi --help`
 
-> **Requirement:** The environment shall contain a `cmake-re` remote rpc server
+```bash
+> $ cmake-re --version
+cmake-re v0.0.72 (distro id: de3f03a)
+```
+
+## Custom containerized environments
+
+> **Requirement:** The environment has to contain a `cmake-re` remote rpc server
 > This can be setup as in the following example.
 
-To get the minimum required to bootstrap an hermetic build, a ready-made setup script for your environment can be setup for use with CMake RE : 
+You can use the following ready-made setup scripts to install the required components into mainstream distribution based container images: 
 
 | System Family  | CMake RE remote server setup script                                                 |
 |----------------|-------------------------------------------------------------------------------------|
 | Centos, Redhat | https://raw.githubusercontent.com/tipi-build/cli/master/install/container/ubuntu.sh |
 | Ubuntu, Debian | https://raw.githubusercontent.com/tipi-build/cli/master/install/container/centos.sh |
 
-### Custom Docker Environment Example
+By default both scripts install only a minimal set of tools and put the `tipi` distribution into `default` mode which **does not** ship any compiler.
+
+To revert to an installation mode more akin to the tipi desktop installation the following environment settings can be set before running the installer script:
+
+- `TIPI_INSTALL_LEGACY_PACKAGES=ON` to install a variety of tools using the system package manager.
+- `TIPI_DISTRO_MODE=all` to ship a full `tipi` / `cmake-re` distribution including the clang based default toolchain.
+
+### Example
+
+In the following let's create an custom build environment based on Ubuntu 24.04
+
+```
+└── environments
+    ├── linux-cxx23.cmake (skipped here)
+    └── linux.pkr.js
+        ├── linux.Dockerfile
+        └── linux.pkr.js
+```
+
 These scripts could be used as follow to make a build environment based on Ubuntu 24.04 :
 
 #### `environments/linux.pkr.js/linux.Dockerfile`
 
 >
-> **NOTE:** This custom environments doesn't contain any C++, Rust of Swift compiler, only the minimum required to perform cached CMake builds, in custom environments the compiler needs to be provided manually. More examples in [tipi-build/environments](https://github.com/tipi-build/environments)
+> **NOTE:** This example environment doesn't contain any compiler. The custom environments need to provide the toolchains manually by installing the required tools as required. More complete examples can be found in [tipi-build/environments](https://github.com/tipi-build/environments)
 
 ```Dockerfile
 ARG UBUNTU_24_04="ubuntu@sha256:04f510bf1f2528604dc2ff46b517dbdbb85c262d62eacc4aa4d3629783036096"
@@ -93,14 +122,10 @@ WORKDIR /home/tipi
 EXPOSE 22
 ```
 
-The matching folder `environments/linux.pkr.js/` will be the docker context and all files in this folder will be provided for the build of the container image.
+The folder `environments/linux.pkr.js/` will be the used as docker build context and all files in this folder will be provided for the build of the container image.
 
-As illustrated in [tipi-build/get-started](https://github.com/tipi-build/get-started), having this container used by `cmake-re` in a build is possible by pointing to the matching CMAKE_TOOLCHAIN_FILE `cmake-re -S . -DCMAKE_TOOLCHAIN_FILE=environments/linux.cmake -B build`.
 
 #### `environments/linux.pkr.js/linux.pkr.js`
->
-> **NOTE:** `cmake-re` will pull the image `tipibuild/testapp-cmake-re-containerized` and use it if it exists, if it doesn't exists or is outdated the `environments/linux.pkr.js/linux.Dockerfile` will be used to create or update it.
->
 
 ```js
 {
@@ -108,7 +133,7 @@ As illustrated in [tipi-build/get-started](https://github.com/tipi-build/get-sta
   "builders": [
     {
       "type": "docker",
-      "image": "tipibuild/testapp-cmake-re-containerized:{{tipi_cli_local_version}}",
+      "image": "tipibuild/testapp-cmake-re-containerized:latest",
       "commit": true
     }
   ],
@@ -119,8 +144,28 @@ As illustrated in [tipi-build/get-started](https://github.com/tipi-build/get-sta
       "tag": "latest"
     }
   ]
-  ,"_tipi_version":"{{tipi_version_hash}}"
 }
 ```
+> With this environment description `cmake-re` will pull the image `tipibuild/testapp-cmake-re-containerized:latest` and use it is valid.
+> Should it not exist or be *outdated* the `environments/linux.pkr.js/linux.Dockerfile` will be used to create or update it.
+
+Please note that `cmake-re` will rely on the provided image to contain an installation matching the version of `cmake-re` used on the host system. Interoperability between different versions is not guaranteed. 
+
+If required, `cmake-re` can inject version information into the environment description file (`linux.pkr.js` in this example) during the **environment generalization** process. This ties the environment description content hash to the version of `cmake-re` running the container image build. The preferred placeholder for this is `{{cmake_re_source_hash}}` which will be replaced by the exact source revision that was used to build the release of `cmake-re` (this is a git revision hash).
+
+> The official tipi container images are using the `{{cmake_re_source_hash}}` placeholder in this way:
+> ```json
+> ...
+> "image": "tipibuild/tipi-ubuntu:{{cmake_re_source_hash}}",
+> ...
+> ```
+
+**Optionally** the `image` reference in `.pkr.js` environment description can be replaced with a *hard reference* (e.g. the docker image name with a repository digest referencing one exact immutable image) to pin the image. In this case the environment description does not need to contain a Dockerfile.
+
+#### Detection of image validity
+
+`cmake-re` will add an image label to the generated image during the build of the container image to mark the container image with the specific environment description content hash (the value is computed before the container build and it is stored as `build.tipi.environment_fingerprint` build config label). This value will be checked prior to using the container to detect changes and to avoid *container name/tag-based* mismatches.
+
+This means that a single character change to the environment specification (all files in the `<environment-name>.pkr.js/` folder) will trigger a rebuild of the container image even if an image with the same reference name exists in the container registry. This check can be bypassed by referencing the container with a *hard reference* (see note above).
 
 

--- a/0400-environments.md
+++ b/0400-environments.md
@@ -56,7 +56,7 @@ When `cmake-re` is provided `-DCMAKE_TOOLCHAIN_FILE=environments/linux-cxx23.cma
 Because in this example there are no `environments/linux-cxx23.layers.json` any change to `linux.pkr.js` would also affect rebuilding any code dependent `linux-cxx23.cmake`, if this isn't desired it's possible to add [`linux-cxx23.layers.json`](./0410-environments-layering.md) to isolate environments, while still giving possibility to compose common cmake modules.  
 
 ## Default Environments
-Officially supported environments can be found in the [tipi-build/environments](https://github.com/tipi-build/environments) GitHub repository.
+Officially supported environments can be found in the [tipi-build/environments](https://github.com/tipi-build/environments) GitHub repository, they can be used as example to build custom environments.
 
 They are unpacked in the default environments directory `/usr/local/share/.tipi/<distro>/environments/` (or `C:\.tipi\<distro>\environments\`).
 
@@ -73,23 +73,31 @@ To get the minimum required to bootstrap an hermetic build, a ready-made setup s
 | Ubuntu, Debian | https://raw.githubusercontent.com/tipi-build/cli/master/install/container/centos.sh |
 
 ### Custom Docker Environment Example
-These scripts could be used as follow to make a build environment based on Ubuntu 22.04 : 
+These scripts could be used as follow to make a build environment based on Ubuntu 24.04 :
 
 #### `environments/linux.pkr.js/linux.Dockerfile`
+
+>
+> **NOTE:** This custom environments doesn't contain any C++, Rust of Swift compiler, only the minimum required to perform cached CMake builds, in custom environments the compiler needs to be provided manually. More examples in [tipi-build/environments](https://github.com/tipi-build/environments)
+
 ```Dockerfile
-FROM ubuntu:22.04
-ENV TIPI_DISTRO_MODE=all
+ARG UBUNTU_24_04="ubuntu@sha256:04f510bf1f2528604dc2ff46b517dbdbb85c262d62eacc4aa4d3629783036096"
+FROM ${UBUNTU_24_04}
 
 ARG DEBIAN_FRONTEND=noninteractive # avoid tzdata asking for configuration
-# Install needed tools
-RUN apt update -y && apt install -y curl
+# Install tipi and cmake-re
+RUN apt update -y && apt install -y curl gettext
 RUN curl -fsSL https://raw.githubusercontent.com/tipi-build/cli/master/install/container/ubuntu.sh -o ubuntu.sh && /bin/bash ubuntu.sh
+USER tipi
+WORKDIR /home/tipi
 EXPOSE 22
 ```
 
+The matching folder `environments/linux.pkr.js/` will be the docker context and all files in this folder will be provided for the build of the container image.
+
+As illustrated in [tipi-build/get-started](https://github.com/tipi-build/get-started), having this container used by `cmake-re` in a build is possible by pointing to the matching CMAKE_TOOLCHAIN_FILE `cmake-re -S . -DCMAKE_TOOLCHAIN_FILE=environments/linux.cmake -B build`.
 
 #### `environments/linux.pkr.js/linux.pkr.js`
-
 >
 > **NOTE:** `cmake-re` will pull the image `tipibuild/testapp-cmake-re-containerized` and use it if it exists, if it doesn't exists or is outdated the `environments/linux.pkr.js/linux.Dockerfile` will be used to create or update it.
 >
@@ -100,7 +108,7 @@ EXPOSE 22
   "builders": [
     {
       "type": "docker",
-      "image": "tipibuild/testapp-cmake-re-containerized:{{tipi_cli_version}}",
+      "image": "tipibuild/testapp-cmake-re-containerized:{{tipi_cli_local_version}}",
       "commit": true
     }
   ],

--- a/1500-environment-variables.md
+++ b/1500-environment-variables.md
@@ -73,3 +73,33 @@ export TIPI_DISTRO_MODE="all" # "full" install - takes ~7gb in TIPI_HOME_DIR
  - or -
 export TIPI_DISTRO_MODE="default" # "light" install for remote builds
 ```
+
+## Tipi container build local registry port `TIPI_LOCAL_REGISTRY_PORT`
+
+> In order to provide a consistent cache keying for containerized (both local and remote) and distributed tipi and cmake-re generate a environment description 
+> that contains a hard reference to the container that will be used to execute the build.
+>
+> This process requires that locally built images (read: a `Dockerfile` is provided as part of the environment specification and there is no matching and valid 
+> image available on the registry) be pushed to a registry to generate that hard reference data if the docker runtime of the host system is not using and OCI
+> compliant internal storage for the images (read: most Docker installations on Linux at time of writing).
+>
+> To automate this process `tipi` and `cmake-re` will start an ephemeral local container registry and push to that as needed to generate the required data.
+
+By default the ephemeral local container registry will be hosted on `127.0.0.1:43113` 
+
+The port can be changed by setting the environment variable `TIPI_LOCAL_REGISTRY_PORT` to any integer value in the range [1024 - 65535].
+
+## Passing additional parameters to the environment build command `TIPI_CONTAINER_BUILD_ADDITIONAL_PARAMETERS`
+
+Additional parameters (docker buildx arguments) can be passed to the environment builder by setting the environment variable `TIPI_CONTAINER_BUILD_ADDITIONAL_PARAMETERS` 
+before running a build that will determine that a container image needs rebuilding.
+
+This can be useful if one needs to set a build tag or image label in a CI setup that is making environment images available to developers:
+
+```bash
+export TIPI_CONTAINER_BUILD_ADDITIONAL_PARAMETERS=--label org.myself.note=hello --tag localref123:latest
+```
+
+After running the build of the container image the image build configuration will contain the `org.myself.note` label and the image will be available as `localref123:latest` on the host.
+
+> Note: changes to this parameters will not be taken into account during the computation of cache keys or the like nor will they trigger a re-build of an otherwise unchanged environment

--- a/1500-environment-variables.md
+++ b/1500-environment-variables.md
@@ -76,11 +76,11 @@ export TIPI_DISTRO_MODE="default" # "light" install for remote builds
 
 ## Tipi container build local registry port `TIPI_LOCAL_REGISTRY_PORT`
 
-> In order to provide a consistent cache keying for containerized (both local and remote) and distributed tipi and cmake-re generate a environment description 
+> In order to provide a consistent cache keying for containerized (both local and remote) and distributed tipi and cmake-re generate an environment description 
 > that contains a hard reference to the container that will be used to execute the build.
 >
 > This process requires that locally built images (read: a `Dockerfile` is provided as part of the environment specification and there is no matching and valid 
-> image available on the registry) be pushed to a registry to generate that hard reference data if the docker runtime of the host system is not using and OCI
+> image available on the registry) be pushed to a registry to generate that hard reference data if the docker runtime of the host system is not using an OCI
 > compliant internal storage for the images (read: most Docker installations on Linux at time of writing).
 >
 > To automate this process `tipi` and `cmake-re` will start an ephemeral local container registry and push to that as needed to generate the required data.
@@ -97,9 +97,9 @@ before running a build that will determine that a container image needs rebuildi
 This can be useful if one needs to set a build tag or image label in a CI setup that is making environment images available to developers:
 
 ```bash
-export TIPI_CONTAINER_BUILD_ADDITIONAL_PARAMETERS=--label org.myself.note=hello --tag localref123:latest
+export TIPI_CONTAINER_BUILD_ADDITIONAL_PARAMETERS="--label org.myself.note=hello --tag localref123:latest"
 ```
 
 After running the build of the container image the image build configuration will contain the `org.myself.note` label and the image will be available as `localref123:latest` on the host.
 
-> Note: changes to this parameters will not be taken into account during the computation of cache keys or the like nor will they trigger a re-build of an otherwise unchanged environment
+> ⚠️ Note: changes to this parameters will not be taken into account during the computation of cache keys or the like nor will they trigger a re-build of an otherwise unchanged environment.


### PR DESCRIPTION
This enforces good practices of specifiying the exact docker hash while also providing an installation of cmake-re/tipi that is minimal. In that it does use the default distro mode, not the "all" mode which would otherwise downloads tipi default compiler.

Relates to tipi-build/specs-cmake-re#124