### PR TITLE
:book: Explain how cmake-re tooling can be integrated as ccache remote_storage alternative

### DIFF
--- a/0010-custom-build-system.md
+++ b/0010-custom-build-system.md
@@ -1,0 +1,90 @@
+---
+title: 🛸 Custom build systems
+aliases: [ ]
+---
+
+While `cmake-re` is optimized for CMake-based builds, it can also operate as a compiler, linker and archiver driver — making it compatible with other build systems that are not directly supported (autotools, Make, Ninja, MSBuild) or as [distcc, ccache, sccache alternative](documentation/0359-ccache-storage-service).
+
+In these cases, it can delivers most of the performance benefits of [⚡️ L2 Distributed Builds & Caching](/documentation/0352-distributed-builds), here follows how to use it.
+
+The binary of `cmake-re` is distributed with the following tools :
+
+- `tipi-compiler-driver`
+- `tipi-linker-driver`
+- `tipi-ar-driver`
+- `tipi-ranlib-driver`
+
+## Ecosystems and tools supported automatically
+- `C` & `C++` : gcc,clang,msvc,ar,ranlib,ld,gold,lld,mold...
+- `Java` : javac
+- `TypeScript` : tsc
+
+### `env:RBE_labels="type=tool"` : custom tools support
+Through the specification of environment's variables `env:RBE_labels="type=tool"`, `env:RBE_input_list_paths` and `env:RBE_output_list_paths`, any custom tools can be supported and the generic `rewrapper` can be taught which file to cache and upload/download files necessary for the tool execution in a remote execution context.
+
+1. Install necessary tools
+
+```bash
+# Linux & MacOS:
+/bin/bash -c \
+ "$(curl -fsSL https://raw.githubusercontent.com/tipi-build/cli/master/install/install_for_macos_linux.sh)"
+```
+
+```powershell
+# Windows 10 / 11 in Powershell
+[Net.ServicePointManager]::SecurityProtocol = "Tls, Tls11, Tls12, Ssl3"
+. { `
+  iwr -useb https://raw.githubusercontent.com/tipi-build/cli/master/install/install_for_windows.ps1 `
+} | iex
+```
+
+
+2. Setup a virtual environment with `tipi run bash` / `tipi.exe run cmd`
+3. [Authenticate to the remote caching service](/documentation/0352-distributed-builds#authenticate-with-an-mtls-certificate) by setting `RBE_service`,`RBE_tls_client_auth_key`,`RBE_tls_client_auth_cert`
+
+4. Start remote execution proxy
+```bash
+export RBE_exec_root=$PWD
+export RBE_platform="InputRootAbsolutePath=$PWD"
+
+# Start remote execution proxy
+touch $PWD.unix-sock-reproxy
+export RBE_server_address=unix://$PWD.unix-sock-reproxy
+export RBE_reproxy_wait_seconds=5
+export RBE_service_no_auth="true"
+export RBE_use_application_default_credentials="true"
+reproxy & 
+```
+
+5. Override compiler,linker and archiver command invocations.
+#### Autotools / Makefiles
+```bash
+export CXX="tipi-compiler-driver c++"
+export CC="tipi-compiler-driver cc"
+export LD="tipi-linker-driver /usr/bin/ld"
+export AR="tipi-ranlib-driver /usr/bin/ar"
+export RANLIB="tipi-ranlib-driver /usr/bin/ranlib"
+
+# Configuration
+./configure
+
+# Build
+# Caching is better disabled during configure (so long 
+# TIPI_INTERCALATED_COMPILER_LAUNCHER is unset no caching happens), as
+# caching system probing operations will only store non really reusable
+# cache entries.
+export TIPI_INTERCALATED_COMPILER_LAUNCHER=rewrapper
+
+make
+```
+
+#### Visual Studio msbuild 
+If you have a CMake codebase [we advice to use the `cmake-re` wrapper](/documentation/0000-getting-started-cmake) but if you use self-maintained Visual Studio Solution, an integration could be done in the following way : 
+
+Edit `<project>.vcxproj`, and **append at the end** after the line importing `Microsoft.Cpp.targets` : 
+```xml
+<PropertyGroup>
+  <CLToolExe>tipi-compiler-driver.exe</CLToolExe>
+  <CLToolPath>c:\.tipi\tipi-compiler-driver\<cmake-re-release-hash>\</CLToolPath>
+</PropertyGroup>
+```

--- a/0010-custom-build-system.md
+++ b/0010-custom-build-system.md
@@ -3,9 +3,9 @@ title: 🛸 Custom build systems
 aliases: [ ]
 ---
 
-While `cmake-re` is optimized for CMake-based builds, it can also operate as a compiler, linker and archiver driver — making it compatible with other build systems that are not directly supported (autotools, Make, Ninja, MSBuild) or as [distcc, ccache, sccache alternative](documentation/0359-ccache-storage-service).
+While `cmake-re` is optimized for CMake-based builds, it can also operate as a compiler, linker and archiver driver — making it compatible with other build systems that are not directly supported (autotools, Make, Ninja, MSBuild) or usable as [distcc, ccache, sccache alternative](documentation/0359-ccache-storage-service).
 
-In these cases, it can delivers most of the performance benefits of [⚡️ L2 Distributed Builds & Caching](/documentation/0352-distributed-builds), here follows how to use it.
+In this mode of operation it can delivers most of the performances benefits of [⚡️ L2 Distributed Builds & Caching](/documentation/0352-distributed-builds), here follows how to use it.
 
 The binary of `cmake-re` is distributed with the following tools :
 
@@ -15,12 +15,16 @@ The binary of `cmake-re` is distributed with the following tools :
 - `tipi-ranlib-driver`
 
 ## Ecosystems and tools supported automatically
-- `C` & `C++` : gcc,clang,msvc,ar,ranlib,ld,gold,lld,mold...
+- `C` & `C++` : gcc, clang, msvc, ar, ranlib, ld, gold, lld, mold...
 - `Java` : javac
 - `TypeScript` : tsc
 
 ### `env:RBE_labels="type=tool"` : custom tools support
-Through the specification of environment's variables `env:RBE_labels="type=tool"`, `env:RBE_input_list_paths` and `env:RBE_output_list_paths`, any custom tools can be supported and the generic `rewrapper` can be taught which file to cache and upload/download files necessary for the tool execution in a remote execution context.
+Custom tool support can be added by specifying the following environment variables that are consumed by rewrapper to control inputs and remote execution context:
+
+- `env:RBE_labels="type=tool"`
+- `env:RBE_input_list_paths`
+- `env:RBE_output_list_paths`
 
 1. Install necessary tools
 
@@ -56,7 +60,7 @@ export RBE_use_application_default_credentials="true"
 reproxy & 
 ```
 
-5. Override compiler,linker and archiver command invocations.
+5. Override compiler, linker and archiver command invocations.
 #### Autotools / Makefiles
 ```bash
 export CXX="tipi-compiler-driver c++"

--- a/0010-custom-build-system.md
+++ b/0010-custom-build-system.md
@@ -3,7 +3,7 @@ title: 🛸 Custom build systems
 aliases: [ ]
 ---
 
-While `cmake-re` is optimized for CMake-based builds, it can also operate as a compiler, linker and archiver driver — making it compatible with other build systems that are not directly supported (autotools, Make, Ninja, MSBuild) or usable as [distcc, ccache, sccache alternative](documentation/0359-ccache-storage-service).
+While `cmake-re` is optimized for CMake-based builds, it can also operate as a compiler, linker and archiver launcher — making it compatible with other build systems that are not directly supported (autotools, Make, Ninja, MSBuild) or usable as [distcc, ccache, sccache alternative](documentation/0359-ccache-storage-service).
 
 In this mode of operation it can delivers most of the performances benefits of [⚡️ L2 Distributed Builds & Caching](/documentation/0352-distributed-builds), here follows how to use it.
 
@@ -13,6 +13,8 @@ The binary of `cmake-re` is distributed with the following tools :
 - `tipi-linker-driver`
 - `tipi-ar-driver`
 - `tipi-ranlib-driver`
+- `reproxy`
+- `rewrapper`
 
 ## Ecosystems and tools supported automatically
 - `C` & `C++` : gcc, clang, msvc, ar, ranlib, ld, gold, lld, mold...
@@ -73,10 +75,11 @@ export RANLIB="tipi-ranlib-driver /usr/bin/ranlib"
 ./configure
 
 # Build
-# Caching is better disabled during configure (so long 
-# TIPI_INTERCALATED_COMPILER_LAUNCHER is unset no caching happens), as
-# caching system probing operations will only store non really reusable
-# cache entries.
+# Caching is better disabled during configuration steps.
+# When the environment vairable TIPI_INTERCALATED_COMPILER_LAUNCHER is not set,
+# no calls to the RE-APIs are made and all work is local. 
+# The compiler invocations for configuration purposes are faster to run
+# locally as they are usually using temporary files that can't be cached.
 export TIPI_INTERCALATED_COMPILER_LAUNCHER=rewrapper
 
 make

--- a/0010-custom-build-system.md
+++ b/0010-custom-build-system.md
@@ -3,7 +3,7 @@ title: 🛸 Custom build systems
 aliases: [ ]
 ---
 
-While `cmake-re` is optimized for CMake-based builds, it can also operate as a compiler, linker and archiver launcher — making it compatible with other build systems that are not directly supported (autotools, Make, Ninja, MSBuild) or usable as [distcc, ccache, sccache alternative](documentation/0359-ccache-storage-service).
+While `cmake-re` is optimized for CMake-based builds, it can also operate as compiler/linker/archiver launcher — making it compatible with other build systems that are not directly supported (autotools, Make, Ninja, MSBuild) or usable as [distcc, ccache, sccache alternative](documentation/0359-ccache-storage-service).
 
 In this mode of operation it can delivers most of the performances benefits of [⚡️ L2 Distributed Builds & Caching](/documentation/0352-distributed-builds), here follows how to use it.
 
@@ -22,7 +22,7 @@ The binary of `cmake-re` is distributed with the following tools :
 - `TypeScript` : tsc
 
 ### `env:RBE_labels="type=tool"` : custom tools support
-Custom tool support can be added by specifying the following environment variables that are consumed by rewrapper to control inputs and remote execution context:
+Custom tool support can be added by specifying the following environment variables that are consumed by `rewrapper` to control inputs and remote execution context:
 
 - `env:RBE_labels="type=tool"`
 - `env:RBE_input_list_paths`

--- a/0359-ccache-storage-service.md
+++ b/0359-ccache-storage-service.md
@@ -1,9 +1,9 @@
 ---
-title: 📦 ccache remote storage
+title: 📦 L2 remote caching with `ccache`
 aliases: [ ]
 ---
 
-While `cmake-re` is optimized for CMake-based builds and automatically provides remote caching for cmake builds, it can also operate as a compiler, linker and archiver driver — making it possible to integrate with `ccache` to provide an RE-API backend as remote shared cache.
+While `cmake-re` is optimized for CMake-based builds and automatically provides remote caching for CMake builds, it can also operate as a compiler, linker and archiver launcher — making it possible to combine RE-API remote cache with a local `ccache`.
 
 Once installed `cmake-re` will provide the following tools as part of it's distribution folder.
 
@@ -11,16 +11,18 @@ Once installed `cmake-re` will provide the following tools as part of it's distr
 - `tipi-linker-driver`
 - `tipi-ar-driver`
 - `tipi-ranlib-driver`
+- `reproxy`
+- `rewrapper`
 
 ## RE-API instead of ccache `remote_storage`
-`ccache` supports it's own remote storage backend, our remote caching for ccache doesn't use this abstraction and instead relies on the more complete [Bazel RE-API](https://github.com/bazelbuild/remote-apis).
+`ccache` supports its own remote storage backend, our solution to integrate remote caching for ccache doesn't use this abstraction and instead relies on the more complete [Bazel RE-API](https://github.com/bazelbuild/remote-apis), combining the best of both systems.
 
-Unlike `ccache` `remote_storage` our integration enables caching static archives, shared objects and executables, also leveraging advanced compiler identification and system fingerprinting to prevent cache poisoning issues. 
+Unlike `ccache` `remote_storage` we extend caching beyond translation-unit compilation, which is the limit of native ccache. Our integration enables caching static archives, shared objects and executables, also leveraging advanced compiler identification and system fingerprinting to prevent cache poisoning issues. 
 
-The approach allows to maximizes cache HIT rates, with the ability to retrieve the full build graph from cache, not only compilation but also caching expensive linking operations, while reducing the amount of cache poisoning issues by being much more precise on the way cache keys are calculated.
+The approach allows to maximize cache HIT rates, with the ability to retrieve the full build graph from cache, not only compilation but also caching expensive linking operations, while reducing the amount of cache poisoning issues by using more precise cache entry matching.
 
-### Using Bazel RE-API as remote `ccache`
-These tools can then be configured to wire a remote cache to `ccache` via the RE-API, leveraging the `CCACHE_PREFIX` setting.
+### Using Bazel RE-API as remote shared `ccache` layer
+Here is how to configure `ccache` to leverage remote caching on an EngFlow RE-API cluster by using the CCACHE_PREFIX setting.
 
 1. Install necessary tools
 
@@ -77,10 +79,11 @@ export RANLIB="tipi-ranlib-driver /usr/bin/ranlib"
 ./configure
 
 # Build
-# Caching is better disabled during configure (so long 
-# TIPI_INTERCALATED_COMPILER_LAUNCHER is unset no caching happens), as
-# caching system probing operations will only store non really reusable
-# cache entries.
+# Caching is better disabled during configuration steps.
+# When the environment vairable TIPI_INTERCALATED_COMPILER_LAUNCHER is not set,
+# no calls to the RE-APIs are made and all work is local. 
+# The compiler invocations for configuration purposes are faster to run
+# locally as they are usually using temporary files that can't be cached.
 export TIPI_INTERCALATED_COMPILER_LAUNCHER=rewrapper
 
 make
@@ -89,12 +92,13 @@ make
 #### CMake
 If you have a CMake codebase [we advise to use `cmake-re`](/documentation/0000-getting-started-cmake) which can further maximize cache HITs through automatic build hermeticity and containerization as it manages caching at the build system level instead of individual invocation only.
 
-If you however want to leverage remote caching with `ccache` instead, here's is how you can wire up remote caching to `ccache`:
+It is also possible to integrate manually with cmake and `ccache` to benefit from local caching and our RE-API based remote caching. Here is an example of such an integration:
 
 ```bash
 # Wire ccache and RE-API Remote Caching
 export CCACHE_PREFIX=tipi-compiler-driver
 
+export CMAKE_C_COMPILER_LAUNCHER=ccache
 export CMAKE_CXX_COMPILER_LAUNCHER=ccache
 export CMAKE_CXX_LINKER_LAUNCHER=tipi-linker-driver
 
@@ -105,17 +109,14 @@ echo "tipi-ranlib-driver /usr/bin/ranlib \$@" > configured-tipi-ranlib-driver &&
 cmake -S . -B ./build/cmake -G Ninja -DCMAKE_AR=$PWD/configured-tipi-ar-driver -DCMAKE_RANLIB=$PWD/configured-tipi-ranlib-driver
 
 # Build
-# Caching is better disabled during configure (so long 
-# TIPI_INTERCALATED_COMPILER_LAUNCHER is unset no caching happens), as
-# caching system probing operations will only store non really reusable
-# cache entries.
+
 export TIPI_INTERCALATED_COMPILER_LAUNCHER=rewrapper
 
 cmake --build ./build/cmake
 ```
 
 > #### Analyzing remote cache HITs
-> In order to check the level of caching achieved and debug / improve it (e.g. detecting generated code files) it is possible to set the RBE_invocation_id as an UUID:
+> In order to download build caching statistics for later analysis (improving cache hit rate or detecting always changing files), you can set the environment variable `RBE_invocation_id` as an UUID. Each separate builds should have a unique value.
 > 
 > ```bash
 > export RBE_invocation_id=`uuidgen`

--- a/0359-ccache-storage-service.md
+++ b/0359-ccache-storage-service.md
@@ -1,0 +1,130 @@
+---
+title: 📦 ccache remote storage
+aliases: [ ]
+---
+
+While `cmake-re` is optimized for CMake-based builds, it can also operate as a compiler, linker and archiver driver — making it possible to integrate with `ccache` to provide an RE-API backend as remote shared cache.
+
+Once installed `cmake-re` will provide the following tools as part of it's distribution folder.
+
+- `tipi-compiler-driver`
+- `tipi-linker-driver`
+- `tipi-ar-driver`
+- `tipi-ranlib-driver`
+
+## RE-API instead of ccache `remote_storage`
+`ccache` supports it's own remote storage backend, our remote caching for ccache doesn't use this abstraction and instead relies on the more complete [Bazel RE-API](https://github.com/bazelbuild/remote-apis).
+
+Unlike `ccache` remote storage backends our integration supports caching static archives, shared objects and executables, also leveraging advanced compiler identification and system fingerprinting prevent cache poisoning issues. 
+
+The approach allows to maximizes cache HIT rates, with the ability to retrieve the full build graph from cache, not only compilation but also caching expensive linking operations, while reducing the amount of cache poisoning issues by being much more precise on the way cache keys are calculated.
+
+### Using Bazel RE-API as remote `ccache`
+These tools can then be configured to wire a remote cache to cache via the RE-API, leveraging the `CCACHE_PREFIX` setting.
+
+1. Install necessary tools
+
+```bash
+# Linux & MacOS:
+/bin/bash -c \
+ "$(curl -fsSL https://raw.githubusercontent.com/tipi-build/cli/master/install/install_for_macos_linux.sh)"
+```
+
+```powershell
+# Windows 10 / 11 in Powershell
+[Net.ServicePointManager]::SecurityProtocol = "Tls, Tls11, Tls12, Ssl3"
+. { `
+  iwr -useb https://raw.githubusercontent.com/tipi-build/cli/master/install/install_for_windows.ps1 `
+} | iex
+```
+
+2. Setup a virtual environment with `tipi run bash`
+
+3. [Authenticate to the remote caching service](/documentation/0352-distributed-builds#authenticate-with-an-mtls-certificate) by setting `RBE_service`,`RBE_tls_client_auth_key`,`RBE_tls_client_auth_cert`
+
+4. Configure remote caching, from within your project:
+```bash
+# Remote Caching, Local Build execution
+export RBE_exec_strategy=local
+export RBE_exec_root=$PWD
+export RBE_platform="InputRootAbsolutePath=$PWD"
+
+# Start remote execution proxy
+touch $PWD.unix-sock-reproxy
+export RBE_server_address=unix://$PWD.unix-sock-reproxy
+export RBE_reproxy_wait_seconds=5
+export RBE_service_no_auth="true"
+export RBE_use_application_default_credentials="true"
+reproxy & 
+```
+
+5. Configure the project to use ccache and advanced caching for linking
+  - Autotools / Makefiles
+  - CMake
+
+#### Autotools / Makefiles
+```bash
+# Wire ccache and RE-API Remote Caching
+export CCACHE_PREFIX=tipi-compiler-driver
+
+export CXX="ccache c++"
+export CC="ccache cc"
+export LD="tipi-linker-driver /usr/bin/ld"
+export AR="tipi-ranlib-driver /usr/bin/ar"
+export RANLIB="tipi-ranlib-driver /usr/bin/ranlib"
+
+# Configuration
+./configure
+
+# Build
+# Caching is better disabled during configure (so long 
+# TIPI_INTERCALATED_COMPILER_LAUNCHER is unset no caching happens), as
+# caching system probing operations will only store non really reusable
+# cache entries.
+export TIPI_INTERCALATED_COMPILER_LAUNCHER=rewrapper
+
+make
+```
+
+#### CMake
+If you have a CMake codebase [we advice to use the `cmake-re` wrapper](/documentation/0000-getting-started-cmake) which can further maximize cache HITs through automatic build hermeticity and containerization as it intercepts at the build system level instead of individual invocation only (those settings also being made in a smart fashion).
+
+However if for some reasons you are not allowed to modify the `cmake` invocations and are just interested in plugging remote caching into `ccache` you can achieve it on any CMake Codebase as such :
+```bash
+# Wire ccache and RE-API Remote Caching
+export CCACHE_PREFIX=tipi-compiler-driver
+
+export CMAKE_CXX_COMPILER_LAUNCHER=ccache
+export CMAKE_CXX_LINKER_LAUNCHER=tipi-linker-driver
+
+# Plain CMake requires RANLIB / AR overriding to be executable not shell commands
+echo "tipi-ranlib-driver /usr/bin/ar \$@" > configured-tipi-ar-driver && chmod +x configured-tipi-ar-driver
+echo "tipi-ranlib-driver /usr/bin/ranlib \$@" > configured-tipi-ranlib-driver && chmod +x configured-tipi-ranlib-driver
+
+cmake -S . -B ./build/cmake -G Ninja -DCMAKE_AR=$PWD/configured-tipi-ar-driver -DCMAKE_RANLIB=$PWD/configured-tipi-ranlib-driver
+
+# Build
+# Caching is better disabled during configure (so long 
+# TIPI_INTERCALATED_COMPILER_LAUNCHER is unset no caching happens), as
+# caching system probing operations will only store non really reusable
+# cache entries.
+export TIPI_INTERCALATED_COMPILER_LAUNCHER=rewrapper
+
+cmake --build ./build/cmake
+```
+
+> #### Analyzing remote cache HITs
+> In order to check the level of caching achieved and debug / improve it (e.g. detecting generated code files) it is possible to set the RBE_invocation_id as an UUID:
+> 
+> ```bash
+> export RBE_invocation_id=`uuidgen`
+> 
+> # Clear local cache
+> ccache -C
+> ```
+> 
+> Then during the build all actions will be grouped in an EngFlow Profile that can be downloaded from the RE-API Cluster:
+> 
+> - `https://<cluster-address>/api/profiling/v1/instances/default/invocations/${RBE_invocation_id}`
+> 
+> The tracing file can then be analyzed with tools like Chrome Tracing Tools or Perfetto and will list the type of events (i.e. `actionCacheLookup`, `downloadBlob`) to confirm caching is working.

--- a/0359-ccache-storage-service.md
+++ b/0359-ccache-storage-service.md
@@ -3,7 +3,7 @@ title: 📦 L2 remote caching with `ccache`
 aliases: [ ]
 ---
 
-While `cmake-re` is optimized for CMake-based builds and automatically provides remote caching for CMake builds, it can also operate as a compiler, linker and archiver launcher — making it possible to combine RE-API remote cache with a local `ccache`.
+While `cmake-re` is optimized for CMake-based builds and automatically provides remote caching for CMake builds, it can also operate as compiler/linker/archiver launcher — making it possible to combine RE-API remote cache with a local `ccache`.
 
 Once installed `cmake-re` will provide the following tools as part of it's distribution folder.
 
@@ -18,8 +18,6 @@ Once installed `cmake-re` will provide the following tools as part of it's distr
 `ccache` supports its own remote storage backend, our solution to integrate remote caching for ccache doesn't use this abstraction and instead relies on the more complete [Bazel RE-API](https://github.com/bazelbuild/remote-apis), combining the best of both systems.
 
 Unlike `ccache` `remote_storage` we extend caching beyond translation-unit compilation, which is the limit of native ccache. Our integration enables caching static archives, shared objects and executables, also leveraging advanced compiler identification and system fingerprinting to prevent cache poisoning issues. 
-
-The approach allows to maximize cache HIT rates, with the ability to retrieve the full build graph from cache, not only compilation but also caching expensive linking operations, while reducing the amount of cache poisoning issues by using more precise cache entry matching.
 
 ### Using Bazel RE-API as remote shared `ccache` layer
 Here is how to configure `ccache` to leverage remote caching on an EngFlow RE-API cluster by using the `CCACHE_PREFIX` setting.

--- a/0359-ccache-storage-service.md
+++ b/0359-ccache-storage-service.md
@@ -3,7 +3,7 @@ title: 📦 ccache remote storage
 aliases: [ ]
 ---
 
-While `cmake-re` is optimized for CMake-based builds, it can also operate as a compiler, linker and archiver driver — making it possible to integrate with `ccache` to provide an RE-API backend as remote shared cache.
+While `cmake-re` is optimized for CMake-based builds and automatically provides remote caching for cmake builds, it can also operate as a compiler, linker and archiver driver — making it possible to integrate with `ccache` to provide an RE-API backend as remote shared cache.
 
 Once installed `cmake-re` will provide the following tools as part of it's distribution folder.
 
@@ -87,9 +87,10 @@ make
 ```
 
 #### CMake
-If you have a CMake codebase [we advice to use the `cmake-re` wrapper](/documentation/0000-getting-started-cmake) which can further maximize cache HITs through automatic build hermeticity and containerization as it intercepts at the build system level instead of individual invocation only (those settings also being made in a smart fashion).
+If you have a CMake codebase [we advise to use `cmake-re`](/documentation/0000-getting-started-cmake) which can further maximize cache HITs through automatic build hermeticity and containerization as it manages caching at the build system level instead of individual invocation only.
 
-However if for some reasons you are not allowed to modify the `cmake` invocations and are just interested in plugging remote caching into `ccache` you can achieve it on any CMake Codebase as such :
+If you however want to leverage remote caching with `ccache` instead, here's is how you can wire up remote caching to `ccache`:
+
 ```bash
 # Wire ccache and RE-API Remote Caching
 export CCACHE_PREFIX=tipi-compiler-driver
@@ -123,7 +124,7 @@ cmake --build ./build/cmake
 > ccache -C
 > ```
 > 
-> Then during the build all actions will be grouped in an EngFlow Profile that can be downloaded from the RE-API Cluster:
+> All actions will be grouped in an EngFlow Profile using that UUID. The profile can be downloaded from the RE-API Cluster after the build completed:
 > 
 > - `https://<cluster-address>/api/profiling/v1/instances/default/invocations/${RBE_invocation_id}`
 > 

--- a/0359-ccache-storage-service.md
+++ b/0359-ccache-storage-service.md
@@ -22,7 +22,7 @@ Unlike `ccache` `remote_storage` we extend caching beyond translation-unit compi
 The approach allows to maximize cache HIT rates, with the ability to retrieve the full build graph from cache, not only compilation but also caching expensive linking operations, while reducing the amount of cache poisoning issues by using more precise cache entry matching.
 
 ### Using Bazel RE-API as remote shared `ccache` layer
-Here is how to configure `ccache` to leverage remote caching on an EngFlow RE-API cluster by using the CCACHE_PREFIX setting.
+Here is how to configure `ccache` to leverage remote caching on an EngFlow RE-API cluster by using the `CCACHE_PREFIX` setting.
 
 1. Install necessary tools
 

--- a/0359-ccache-storage-service.md
+++ b/0359-ccache-storage-service.md
@@ -15,12 +15,12 @@ Once installed `cmake-re` will provide the following tools as part of it's distr
 ## RE-API instead of ccache `remote_storage`
 `ccache` supports it's own remote storage backend, our remote caching for ccache doesn't use this abstraction and instead relies on the more complete [Bazel RE-API](https://github.com/bazelbuild/remote-apis).
 
-Unlike `ccache` remote storage backends our integration supports caching static archives, shared objects and executables, also leveraging advanced compiler identification and system fingerprinting prevent cache poisoning issues. 
+Unlike `ccache` `remote_storage` our integration enables caching static archives, shared objects and executables, also leveraging advanced compiler identification and system fingerprinting to prevent cache poisoning issues. 
 
 The approach allows to maximizes cache HIT rates, with the ability to retrieve the full build graph from cache, not only compilation but also caching expensive linking operations, while reducing the amount of cache poisoning issues by being much more precise on the way cache keys are calculated.
 
 ### Using Bazel RE-API as remote `ccache`
-These tools can then be configured to wire a remote cache to cache via the RE-API, leveraging the `CCACHE_PREFIX` setting.
+These tools can then be configured to wire a remote cache to `ccache` via the RE-API, leveraging the `CCACHE_PREFIX` setting.
 
 1. Install necessary tools
 

--- a/0400-environments.md
+++ b/0400-environments.md
@@ -27,7 +27,8 @@ A **Generalized toolchain** is a toolchain and it's accompanying environment spe
 
 ### Configurability
 
-Depending on how the environment descriptions and toolchains are stored changes to unrelated environments can affect the environment description hash that is computed during environment generalization because by default all files in the same directory than the referenced toolchain will be consumed.
+Depending on how the environment descriptions and toolchains are stored, changes to unrelated environments can affect the environment description hash. Because by default all files in the same directory of the referenced toolchain will be consumed.
+
 In order to better compose and isolate environment specifications it is possible to configure the exact contents using [`<toolchain-name>.layers.json files`](./0410-environments-layering.md).
 
 ## OS Image File Lookup Rule
@@ -64,11 +65,11 @@ Officially supported environments can be found in the [tipi-build/environments](
 
 They are unpacked in the default environments directory `/usr/local/share/.tipi/<distro>/environments/` (or `C:\.tipi\<distro>\environments\`).
 
-The `disto` ID key can be found by running `cmake-re --version` or `tipi --help`
+The `distro` ID key can be found by running `cmake-re --version` or `tipi --help`
 
 ```bash
 > $ cmake-re --version
-cmake-re v0.0.72 (distro id: de3f03a)
+cmake-re v7.7.7 (distro id: de3f03a)
 ```
 
 ## Custom containerized environments


### PR DESCRIPTION
This explains how ccache can store cache hits on a Bazel RE-API cluster, through the use of CCACHE_PREFIX as well as how it can be complemented to support additionally caching of archiving and linking steps.

The ccache approach has been extensively tested and should always work as it only requires actionCacheLookup, downloadBlob, uploadBlob types of actions.

But it also adds a page explaining how to integrate a custom build system that is not normally supported, the mileage and details of the cluster settings might vary because of execution platforms and labels.

### Integrated in 
- [x] https://github.com/nxxm/indigenious-ci/pull/532

Fix tipi-build/specs-cmake-re#296